### PR TITLE
chore: [SIW-1326] Rename package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ The [example app](/example/) demonstrates usage of the library. You need to run 
 
 It is configured to use the local version of the library, so any changes you make to the library's source code will be reflected in the example app. Changes to the library's JavaScript code will be reflected in the example app without a rebuild, but native code changes will require a rebuild of the example app.
 
-If you want to use Android Studio or XCode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/IoReactNativeSecureStorageExample.xcworkspace` in XCode and find the source files at `Pods > Development Pods > io-react-native-secure-storage`.
+If you want to use Android Studio or XCode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/IoReactNativeSecureStorageExample.xcworkspace` in XCode and find the source files at `Pods > Development Pods > @pagopa/io-react-native-secure-storage`.
 
-To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `io-react-native-secure-storage` under `Android`.
+To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `@pagopa/io-react-native-secure-storage` under `Android`.
 
 You can use various commands from the root directory to work with the project.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# io-react-native-secure-storage
+# @pagopa/io-react-native-secure-storage
 
 React Native interfaces for managing secure storage in iOS and Android.
 
 ## Installation
 
 ```sh
-npm install io-react-native-secure-storage
+npm install @pagopa/io-react-native-secure-storage
 # or
-yarn add io-react-native-secure-storage
+yarn add @pagopa/io-react-native-secure-storage
 ```
 
 ## Android

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -72,12 +72,12 @@ PODS:
   - hermes-engine (0.73.6):
     - hermes-engine/Pre-built (= 0.73.6)
   - hermes-engine/Pre-built (0.73.6)
-  - io-react-native-secure-storage (0.1.0):
+  - libevent (2.1.12)
+  - OpenSSL-Universal (1.1.1100)
+  - pagopa-io-react-native-secure-storage (0.1.1):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - libevent (2.1.12)
-  - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2022.05.16.00):
     - boost
     - DoubleConversion
@@ -1149,9 +1149,9 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (= 0.201.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - io-react-native-secure-storage (from `../..`)
   - libevent (~> 2.1.12)
   - OpenSSL-Universal (= 1.1.1100)
+  - pagopa-io-react-native-secure-storage (from `../..`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -1230,7 +1230,7 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2024-02-20-RNv0.73.5-18f99ace4213052c5e7cdbcd39ee9766cd5df7e4
-  io-react-native-secure-storage:
+  pagopa-io-react-native-secure-storage:
     :path: "../.."
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
@@ -1337,9 +1337,9 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 9cecf9953a681df7556b8cc9c74905de8f3293c0
-  io-react-native-secure-storage: 3f2d3272f4f8246f060492543f39bfa674e6a7f5
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
+  pagopa-io-react-native-secure-storage: 74d89452b0c61d7597bf0c2da34328344036e2cf
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: ca1d7414aba0b27efcfa2ccd37637edb1ab77d96
   RCTTypeSafety: 678e344fb976ff98343ca61dc62e151f3a042292

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,7 +9,7 @@ import {
   TextInput,
   ActivityIndicator,
 } from 'react-native';
-import * as SecureStorage from 'io-react-native-secure-storage';
+import * as SecureStorage from '@pagopa/io-react-native-secure-storage';
 import CheckBox from '@react-native-community/checkbox';
 
 const MARGIN = 20;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "io-react-native-secure-storage",
+  "name": "@pagopa/io-react-native-secure-storage",
   "version": "0.1.1",
   "description": "React Native interfaces for managing secure storage in iOS and Android",
   "main": "lib/commonjs/index",

--- a/pagopa-io-react-native-secure-storage.podspec
+++ b/pagopa-io-react-native-secure-storage.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
-  s.name         = "io-react-native-secure-storage"
+  s.name         = "pagopa-io-react-native-secure-storage"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { NativeModules, Platform } from 'react-native';
 
 const LINKING_ERROR =
-  `The package 'io-react-native-secure-storage' doesn't seem to be linked. Make sure: \n\n` +
+  `The package '@pagopa/io-react-native-secure-storage' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "io-react-native-secure-storage": ["./src/index"]
+      "@pagopa/io-react-native-secure-storage": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,6 +2560,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pagopa/io-react-native-secure-storage@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@pagopa/io-react-native-secure-storage@workspace:."
+  dependencies:
+    "@commitlint/config-conventional": ^17.0.2
+    "@evilmartians/lefthook": ^1.5.0
+    "@react-native/eslint-config": ^0.73.1
+    "@release-it/conventional-changelog": ^5.0.0
+    "@types/jest": ^29.5.5
+    "@types/react": ^18.2.44
+    commitlint: ^17.0.2
+    del-cli: ^5.1.0
+    eslint: ^8.51.0
+    eslint-config-prettier: ^9.0.0
+    eslint-plugin-prettier: ^5.0.1
+    jest: ^29.7.0
+    prettier: ^3.0.3
+    react: 18.2.0
+    react-native: 0.73.6
+    react-native-builder-bob: ^0.20.0
+    release-it: ^15.0.0
+    turbo: ^1.10.7
+    typescript: ^5.2.2
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  languageName: unknown
+  linkType: soft
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -7395,35 +7424,6 @@ __metadata:
     babel-plugin-module-resolver: ^5.0.0
     react: 18.2.0
     react-native: 0.73.6
-  languageName: unknown
-  linkType: soft
-
-"io-react-native-secure-storage@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "io-react-native-secure-storage@workspace:."
-  dependencies:
-    "@commitlint/config-conventional": ^17.0.2
-    "@evilmartians/lefthook": ^1.5.0
-    "@react-native/eslint-config": ^0.73.1
-    "@release-it/conventional-changelog": ^5.0.0
-    "@types/jest": ^29.5.5
-    "@types/react": ^18.2.44
-    commitlint: ^17.0.2
-    del-cli: ^5.1.0
-    eslint: ^8.51.0
-    eslint-config-prettier: ^9.0.0
-    eslint-plugin-prettier: ^5.0.1
-    jest: ^29.7.0
-    prettier: ^3.0.3
-    react: 18.2.0
-    react-native: 0.73.6
-    react-native-builder-bob: ^0.20.0
-    release-it: ^15.0.0
-    turbo: ^1.10.7
-    typescript: ^5.2.2
-  peerDependencies:
-    react: "*"
-    react-native: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Short description
This PR renames the package name to `@pagopa/io-react-native-secure-storage` to keep it coherent with other published packages.

## How to test
Test the example app on both platforms and check if there's any other needed change.