### PR TITLE
refactor: [SIW-1906] Change key access policy for manual encryption

### DIFF
--- a/android/src/main/java/com/pagopa/securestorage/SecureStorage.kt
+++ b/android/src/main/java/com/pagopa/securestorage/SecureStorage.kt
@@ -194,9 +194,8 @@ class SecureStorage private constructor(
       keyAlias, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
     ).setBlockModes(KeyProperties.BLOCK_MODE_GCM).setKeySize(128)
       .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-      if (hasStrongBox) builder.setIsStrongBoxBacked(true)
-      builder.setUnlockedDeviceRequired(true)
+    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) && hasStrongBox) {
+      builder.setIsStrongBoxBacked(true)
     }
     val keyPairGenerator = KeyGenerator.getInstance(
       KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,6 +8,7 @@ import {
   KeyboardAvoidingView,
   TextInput,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import * as SecureStorage from '@pagopa/io-react-native-secure-storage';
 import CheckBox from '@react-native-community/checkbox';
@@ -152,6 +153,7 @@ export default function App() {
     try {
       setIsLoading(true);
       await SecureStorage.tests();
+      Alert.alert('Tests completed');
     } catch (e) {
       const error = e as SecureStorage.SecureStorageError;
       setStatus(`Error: ${error.message}`);


### PR DESCRIPTION
## Short description
The current access policy to the hardware backed key is set by builder.setUnlockedDeviceRequired(true) when using manual encryption.
We are removing this access policy due to a bug in Android 14 and below which prevents the key to be accessed in some scenarios like unlocking with face recognition. More on the subject [here](https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setUnlockedDeviceRequired(boolean)).
It will be enabled only for Android 15 later when we can thoroughly test this.

## List of changes proposed in this pull request
- Remove the access policy for the key used with manual encryption;
- Add an alert when tests are completed in the example app.

## How to test
Run the example app on Android, try to run the tests. Also force encryption and test if everything works just as before.
