### PR TITLE
chore: [SIW-2502] Add native stack in exception 

### DIFF
--- a/android/src/main/java/com/ioreactnativesecurestorage/IoReactNativeSecureStorageModule.kt
+++ b/android/src/main/java/com/ioreactnativesecurestorage/IoReactNativeSecureStorageModule.kt
@@ -67,7 +67,9 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.PUT_FAILED.reject(
-          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
+          promise,
+          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
+          exception = e
         )
       }
     }.start()
@@ -89,7 +91,9 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.GET_FAILED.reject(
-          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
+          promise,
+          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
+          exception = e
         )
       }
     }.start()
@@ -109,7 +113,9 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.CLEAR_FAILED.reject(
-          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
+          promise,
+          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
+          exception = e
         )
       }
     }.start()
@@ -129,7 +135,9 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.REMOVE_FAILED.reject(
-          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
+          promise,
+          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
+          exception = e
         )
       }
     }.start()
@@ -151,7 +159,9 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
       }
     } catch (e: Exception) {
       ModuleException.KEYS_RETRIEVAL_FAILED.reject(
-        promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
+        promise,
+        Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
+        exception = e
       )
     }
   }
@@ -178,7 +188,9 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         promise.resolve(null)
       } catch (e: Exception) {
         ModuleException.TEST_EXCEPTION.reject(
-          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
+          promise,
+          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
+          exception = e
         )
       }
     }.start()
@@ -209,29 +221,25 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
 
       /**
        * Rejects the provided promise with the appropriate error message and additional data.
+       * Automatically includes native stack trace when an exception is provided.
        *
-       * @param promise the promise to be rejected.
-       * @param args additional key-value pairs of data to be passed along with the error.
+       * @param promise the promise to be rejected
+       * @param args additional key-value pairs to include in the error data
+       * @param exception optional throwable to include native stack trace (defaults to this.ex)
        */
       fun reject(
-        promise: Promise, vararg args: Pair<String, String>
+        promise: Promise,
+        vararg args: Pair<String, String>,
+        exception: Throwable? = null
       ) {
-        exMap(*args).let {
-          promise.reject(it.first, ex.message, it.second)
-        }
-      }
+        val errorCode = name
+        val errorMessage = this.ex.message ?: "UNKNOWN"
 
-      /**
-       * Maps the additional key-value pairs of data to a pair containing the error message
-       * and a WritableMap of the additional data.
-       *
-       * @param args additional key-value pairs of data.
-       * @return A pair containing the error message and a WritableMap of the additional data.
-       */
-      private fun exMap(vararg args: Pair<String, String>): Pair<String, WritableMap> {
-        val writableMap = WritableNativeMap()
-        args.forEach { writableMap.putString(it.first, it.second) }
-        return Pair(this.ex.message ?: "UNKNOWN", writableMap)
+        val extra = WritableNativeMap().apply {
+          args.forEach { putString(it.first, it.second) }
+        }
+
+        promise.reject(errorCode, errorMessage, exception ?: this.ex, extra)
       }
     }
   }

--- a/android/src/main/java/com/ioreactnativesecurestorage/IoReactNativeSecureStorageModule.kt
+++ b/android/src/main/java/com/ioreactnativesecurestorage/IoReactNativeSecureStorageModule.kt
@@ -217,7 +217,7 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         promise: Promise, vararg args: Pair<String, String>
       ) {
         exMap(*args).let {
-          promise.reject(it.first, ex.message, it.second)
+          promise.reject(it.first, ex, it.second)
         }
       }
 

--- a/android/src/main/java/com/ioreactnativesecurestorage/IoReactNativeSecureStorageModule.kt
+++ b/android/src/main/java/com/ioreactnativesecurestorage/IoReactNativeSecureStorageModule.kt
@@ -67,9 +67,7 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.PUT_FAILED.reject(
-          promise,
-          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
-          exception = e
+          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
         )
       }
     }.start()
@@ -91,9 +89,7 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.GET_FAILED.reject(
-          promise,
-          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
-          exception = e
+          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
         )
       }
     }.start()
@@ -113,9 +109,7 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.CLEAR_FAILED.reject(
-          promise,
-          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
-          exception = e
+          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
         )
       }
     }.start()
@@ -135,9 +129,7 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         }
       } catch (e: Exception) {
         ModuleException.REMOVE_FAILED.reject(
-          promise,
-          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
-          exception = e
+          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
         )
       }
     }.start()
@@ -159,9 +151,7 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
       }
     } catch (e: Exception) {
       ModuleException.KEYS_RETRIEVAL_FAILED.reject(
-        promise,
-        Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
-        exception = e
+        promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
       )
     }
   }
@@ -188,9 +178,7 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
         promise.resolve(null)
       } catch (e: Exception) {
         ModuleException.TEST_EXCEPTION.reject(
-          promise,
-          Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e)),
-          exception = e
+          promise, Pair(ERROR_USER_INFO_KEY, getExceptionMessageOrEmpty(e))
         )
       }
     }.start()
@@ -221,25 +209,29 @@ class IoReactNativeSecureStorageModule(reactContext: ReactApplicationContext) :
 
       /**
        * Rejects the provided promise with the appropriate error message and additional data.
-       * Automatically includes native stack trace when an exception is provided.
        *
-       * @param promise the promise to be rejected
-       * @param args additional key-value pairs to include in the error data
-       * @param exception optional throwable to include native stack trace (defaults to this.ex)
+       * @param promise the promise to be rejected.
+       * @param args additional key-value pairs of data to be passed along with the error.
        */
       fun reject(
-        promise: Promise,
-        vararg args: Pair<String, String>,
-        exception: Throwable? = null
+        promise: Promise, vararg args: Pair<String, String>
       ) {
-        val errorCode = name
-        val errorMessage = this.ex.message ?: "UNKNOWN"
-
-        val extra = WritableNativeMap().apply {
-          args.forEach { putString(it.first, it.second) }
+        exMap(*args).let {
+          promise.reject(it.first, ex.message, it.second)
         }
+      }
 
-        promise.reject(errorCode, errorMessage, exception ?: this.ex, extra)
+      /**
+       * Maps the additional key-value pairs of data to a pair containing the error message
+       * and a WritableMap of the additional data.
+       *
+       * @param args additional key-value pairs of data.
+       * @return A pair containing the error message and a WritableMap of the additional data.
+       */
+      private fun exMap(vararg args: Pair<String, String>): Pair<String, WritableMap> {
+        val writableMap = WritableNativeMap()
+        args.forEach { writableMap.putString(it.first, it.second) }
+        return Pair(this.ex.message ?: "UNKNOWN", writableMap)
       }
     }
   }

--- a/android/src/main/java/com/pagopa/securestorage/SecureStorage.kt
+++ b/android/src/main/java/com/pagopa/securestorage/SecureStorage.kt
@@ -97,7 +97,6 @@ class SecureStorage private constructor(
    */
   fun get(key: String): ByteArray? {
     return runCatching {
-      throw IllegalStateException("Unrecognized file prefix")
       val file = AtomicFile(getFile(key))
       val data = file.readFully()
       check(data.size >= PREFIX_ENCRYPTED_SIZE) { "File must be bigger than $PREFIX_ENCRYPTED_SIZE bytes" }

--- a/android/src/main/java/com/pagopa/securestorage/SecureStorage.kt
+++ b/android/src/main/java/com/pagopa/securestorage/SecureStorage.kt
@@ -97,6 +97,7 @@ class SecureStorage private constructor(
    */
   fun get(key: String): ByteArray? {
     return runCatching {
+      throw IllegalStateException("Unrecognized file prefix")
       val file = AtomicFile(getFile(key))
       val data = file.readFully()
       check(data.size >= PREFIX_ENCRYPTED_SIZE) { "File must be bigger than $PREFIX_ENCRYPTED_SIZE bytes" }


### PR DESCRIPTION
## Short description
This PR fix native Android stack trace not being populated in React Native promise rejections by passing the complete `Throwable` object instead of just the error message. 

## List of changes proposed in this pull request
- Changed `promise.reject()` call to pass the complete `Throwable` object instead of just `ex.message`

## How to test

1. Trigger an exception in the native `get`method by performing a get operation on the secure storage on the example app
2. Check the exception log, that `nativeStackAndroid` is populated
